### PR TITLE
Modify findUser method to not be case-sensitive when returning result

### DIFF
--- a/src/UserRepo.js
+++ b/src/UserRepo.js
@@ -6,7 +6,8 @@ class UserRepo {
   }
 
   findUser(searchTerm) {
-    return this.users.find(user => user.name.includes(searchTerm));
+    searchTerm = searchTerm.toLowerCase(); 
+    return this.users.find(user => user.name.toLowerCase().includes(searchTerm));
   }
 
   getUserFromId(id) {

--- a/test/UserRepo-test.js
+++ b/test/UserRepo-test.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import UserRepo from '../src/UserRepo';
 import User from '../src/User';
 
-describe('UserRepo', function() {
+describe.only('UserRepo', function() {
   let user1, user2, user3, user4, userRepo;
 
   before(function() {
@@ -32,14 +32,22 @@ describe('UserRepo', function() {
   it('given a full name, it should be able to return the user with that name', function() {
     const getUser = userRepo.findUser('Hayley Williams');
 
-    expect(getUser).to.deep.equal({ id: 24, name: 'Hayley Williams' });
+    expect(getUser).to.deep.equal(user3);
   });
 
   it('given a partial name, it should still be able to return the first user with that name', function() {
     const getUser = userRepo.findUser('Billie');
 
-    expect(getUser).to.deep.equal({ id: 17, name: 'Billie Eilish' });
+    expect(getUser).to.deep.equal(user2);
   });
+
+  it('given a name in any letter case, it should still be able to return the first user with that name', function() {
+    const getUser = userRepo.findUser('billie');
+    const getUser2 = userRepo.findUser('tAYLOr')
+
+    expect(getUser).to.deep.equal(user2);
+    expect(getUser2).to.deep.equal(user1)
+  })
 
   it('should be able to return a user based on an id', function() {
     const userName = userRepo.getUserFromId(10);


### PR DESCRIPTION
#### What changes/additions are a part of this PR?
This modifies the findUser method so that when a manger searches for a user, the user-name does not have to be case-sensitive to return a match.

#### Any background context you want to provide?
None needed
#### Where should the reviewer start?
UserRepo
#### How should this be tested (test suite/manually)?
UserRepo test 
#### What are the relevant tickets?
Ticket #39 
